### PR TITLE
Add environment type selection feature for QA and DEMO environments

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -24,7 +24,8 @@ LOG_LEVEL=info
 # Google Cloud Authentication
 # Required for pulling images from Google Cloud Artifact Registry
 # Service account key JSON content (recommended for containerized environments)
-GOOGLE_CLOUD_KEYFILE=base64_version_of_json
+GOOGLE_CLOUD_KEYFILE_QA=base64_version_of_json
+GOOGLE_CLOUD_KEYFILE_DEMO=base64_version_of_json
 
 # GitHub Authentication
 # Required for pulling images from GitHub Container Registry (ghcr.io)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -69,7 +69,8 @@ services:
       - LOG_LEVEL=${LOG_LEVEL:-info}
       - VERTUOZA_COMPOSE_DIR=/vertuoza-compose
       # Google Cloud Authentication
-      - GOOGLE_CLOUD_KEYFILE=${GOOGLE_CLOUD_KEYFILE}
+      - GOOGLE_CLOUD_KEYFILE_QA=${GOOGLE_CLOUD_KEYFILE_QA}
+      - GOOGLE_CLOUD_KEYFILE_DEMO=${GOOGLE_CLOUD_KEYFILE_DEMO}
       # GitHub Authentication
       - GITHUB_TOKEN=${GITHUB_TOKEN}
     ports:

--- a/ephemeral-environments-api/docs/api-reference.md
+++ b/ephemeral-environments-api/docs/api-reference.md
@@ -15,21 +15,33 @@ POST /api/environments
 Request body:
 ```json
 {
-  "service_name": "kernel",
+  "repository_name": "vertuoza",
   "pr_number": 123,
-  "image_url": "europe-west1-docker.pkg.dev/vertuoza-qa/vertuoza/kernel:pr-123"
+  "environment_type": "qa", // Optional, defaults to "qa", can be "qa" or "demo"
+  "services": [
+    {
+      "name": "kernel",
+      "image_url": "europe-west1-docker.pkg.dev/vertuoza-qa/vertuoza/kernel:pr-123"
+    }
+  ]
 }
 ```
 
 Response:
 ```json
 {
-  "id": "kernel-pr-123",
-  "serviceName": "kernel",
+  "id": "vertuoza-pr-123",
+  "repositoryName": "vertuoza",
+  "services": [
+    {
+      "name": "kernel",
+      "imageUrl": "europe-west1-docker.pkg.dev/vertuoza-qa/vertuoza/kernel:pr-123"
+    }
+  ],
   "prNumber": 123,
   "status": "running",
-  "url": "https://kernel-pr-123.tailf31c84.ts.net",
-  "imageUrl": "europe-west1-docker.pkg.dev/vertuoza-qa/vertuoza/kernel:pr-123"
+  "url": "https://vertuoza-pr-123.tailf31c84.ts.net",
+  "environmentType": "qa"
 }
 ```
 
@@ -42,19 +54,32 @@ PUT /api/environments/:id
 Request body:
 ```json
 {
-  "image_url": "europe-west1-docker.pkg.dev/vertuoza-qa/vertuoza/kernel:pr-123-updated"
+  "repository_name": "vertuoza",
+  "environment_type": "demo", // Optional, defaults to "qa", can be "qa" or "demo"
+  "services": [
+    {
+      "name": "kernel",
+      "image_url": "europe-west1-docker.pkg.dev/vertuoza-demo-382712/vertuoza/kernel:pr-123-updated"
+    }
+  ]
 }
 ```
 
 Response:
 ```json
 {
-  "id": "kernel-pr-123",
-  "serviceName": "kernel",
+  "id": "vertuoza-pr-123",
+  "repositoryName": "vertuoza",
+  "services": [
+    {
+      "name": "kernel",
+      "imageUrl": "europe-west1-docker.pkg.dev/vertuoza-demo-382712/vertuoza/kernel:pr-123-updated"
+    }
+  ],
   "prNumber": 123,
   "status": "running",
-  "url": "https://kernel-pr-123.tailf31c84.ts.net",
-  "imageUrl": "europe-west1-docker.pkg.dev/vertuoza-qa/vertuoza/kernel:pr-123-updated"
+  "url": "https://vertuoza-pr-123.tailf31c84.ts.net",
+  "environmentType": "demo"
 }
 ```
 
@@ -82,12 +107,18 @@ GET /api/environments/:id
 Response:
 ```json
 {
-  "id": "kernel-pr-123",
-  "serviceName": "kernel",
+  "id": "vertuoza-pr-123",
+  "repositoryName": "vertuoza",
+  "services": [
+    {
+      "name": "kernel",
+      "imageUrl": "europe-west1-docker.pkg.dev/vertuoza-qa/vertuoza/kernel:pr-123"
+    }
+  ],
   "prNumber": 123,
   "status": "running",
-  "url": "https://kernel-pr-123.tailf31c84.ts.net",
-  "imageUrl": "europe-west1-docker.pkg.dev/vertuoza-qa/vertuoza/kernel:pr-123",
+  "url": "https://vertuoza-pr-123.tailf31c84.ts.net",
+  "environmentType": "qa",
   "createdAt": "2025-05-08T11:18:30.000Z",
   "updatedAt": "2025-05-08T11:18:30.000Z"
 }
@@ -101,7 +132,7 @@ GET /api/environments
 
 Query parameters:
 - `status`: Filter by status (e.g., `running`, `removed`)
-- `service_name`: Filter by service name
+- `repository_name`: Filter by repository name
 - `pr_number`: Filter by PR number
 
 Response:
@@ -109,12 +140,18 @@ Response:
 {
   "environments": [
     {
-      "id": "kernel-pr-123",
-      "serviceName": "kernel",
+      "id": "vertuoza-pr-123",
+      "repositoryName": "vertuoza",
+      "services": [
+        {
+          "name": "kernel",
+          "imageUrl": "europe-west1-docker.pkg.dev/vertuoza-qa/vertuoza/kernel:pr-123"
+        }
+      ],
       "prNumber": 123,
       "status": "running",
-      "url": "https://kernel-pr-123.tailf31c84.ts.net",
-      "imageUrl": "europe-west1-docker.pkg.dev/vertuoza-qa/vertuoza/kernel:pr-123",
+      "url": "https://vertuoza-pr-123.tailf31c84.ts.net",
+      "environmentType": "qa",
       "createdAt": "2025-05-08T11:18:30.000Z",
       "updatedAt": "2025-05-08T11:18:30.000Z"
     }

--- a/ephemeral-environments-api/docs/setup-guide.md
+++ b/ephemeral-environments-api/docs/setup-guide.md
@@ -35,6 +35,30 @@ This script will:
 
 > **Security Note**: The installation script will prompt you for your Tailscale auth key, which is used to authenticate the Ephemeral Environment API Server with Tailscale. You can get your Tailscale auth key from the [Tailscale admin console](https://login.tailscale.com/admin/settings/keys).
 
+### 3. Configure Google Cloud Authentication
+
+The API server supports pulling Docker images from both QA and DEMO environments in Google Cloud Artifact Registry. To configure this:
+
+1. Get the service account key JSON files for both environments
+2. Convert them to base64:
+
+```bash
+cat qa-service-account.json | base64 -w 0 > qa-service-account-base64.txt
+cat demo-service-account.json | base64 -w 0 > demo-service-account-base64.txt
+```
+
+3. Add the base64-encoded keys to your `.env` file:
+
+```
+# Google Cloud Authentication for QA environment
+GOOGLE_CLOUD_KEYFILE_QA=<base64-encoded-qa-service-account-key>
+
+# Google Cloud Authentication for DEMO environment
+GOOGLE_CLOUD_KEYFILE_DEMO=<base64-encoded-demo-service-account-key>
+```
+
+This allows the API server to authenticate with Google Cloud and pull images from either the QA or DEMO environment based on the `environment_type` parameter specified when creating an environment.
+
 ### 4. Verify the Installation
 
 Check that the API server is running:

--- a/ephemeral-environments-api/src/index.js
+++ b/ephemeral-environments-api/src/index.js
@@ -8,6 +8,7 @@ const { setupDatabase } = require('./database');
 const { logger } = require('./utils/logger');
 const fileSystem = require('./utils/fileSystem');
 const { addEnvironmentTypeColumn } = require('./migrations/add_environment_type');
+const { updateEnvironmentSchema } = require('./migrations/update_environment_schema');
 
 // Load environment variables
 dotenv.config({ path: fileSystem.joinPath(__dirname, '../.env') });
@@ -61,6 +62,7 @@ async function startServer() {
 
     // Run migrations
     await addEnvironmentTypeColumn();
+    await updateEnvironmentSchema();
 
     // Start the server
     app.listen(PORT, '0.0.0.0', () => {

--- a/ephemeral-environments-api/src/index.js
+++ b/ephemeral-environments-api/src/index.js
@@ -7,6 +7,7 @@ const cors = require('cors');
 const { setupDatabase } = require('./database');
 const { logger } = require('./utils/logger');
 const fileSystem = require('./utils/fileSystem');
+const { addEnvironmentTypeColumn } = require('./migrations/add_environment_type');
 
 // Load environment variables
 dotenv.config({ path: fileSystem.joinPath(__dirname, '../.env') });
@@ -57,6 +58,9 @@ async function startServer() {
   try {
     // Initialize the database
     await setupDatabase();
+
+    // Run migrations
+    await addEnvironmentTypeColumn();
 
     // Start the server
     app.listen(PORT, '0.0.0.0', () => {

--- a/ephemeral-environments-api/src/migrations/add_environment_type.js
+++ b/ephemeral-environments-api/src/migrations/add_environment_type.js
@@ -1,0 +1,39 @@
+const { logger } = require('../utils/logger');
+const { getDb } = require('../database');
+
+/**
+ * Add environment_type column to environments table
+ */
+async function addEnvironmentTypeColumn() {
+  try {
+    const db = getDb();
+
+    // Check if the column already exists
+    const [columns] = await db.query(`
+      SELECT COLUMN_NAME
+      FROM INFORMATION_SCHEMA.COLUMNS
+      WHERE TABLE_NAME = 'environments'
+      AND COLUMN_NAME = 'environment_type'
+    `);
+
+    if (columns.length === 0) {
+      // Column doesn't exist, add it
+      await db.query(`
+        ALTER TABLE environments
+        ADD COLUMN environment_type VARCHAR(10) DEFAULT 'qa'
+      `);
+      logger.info('Added environment_type column to environments table');
+    } else {
+      logger.info('environment_type column already exists in environments table');
+    }
+
+    return { success: true };
+  } catch (err) {
+    logger.error(`Error adding environment_type column: ${err.message}`);
+    throw err;
+  }
+}
+
+module.exports = {
+  addEnvironmentTypeColumn
+};

--- a/ephemeral-environments-api/src/migrations/update_environment_schema.js
+++ b/ephemeral-environments-api/src/migrations/update_environment_schema.js
@@ -1,0 +1,51 @@
+const { logger } = require('../utils/logger');
+const { getDb } = require('../database');
+
+/**
+ * Update environments table to make repository_name and pr_number nullable
+ * for DEMO environments
+ */
+async function updateEnvironmentSchema() {
+  try {
+    const db = getDb();
+
+    // Check if the environment_type column exists
+    const [envTypeColumns] = await db.query(`
+      SELECT COLUMN_NAME
+      FROM INFORMATION_SCHEMA.COLUMNS
+      WHERE TABLE_NAME = 'environments'
+      AND COLUMN_NAME = 'environment_type'
+    `);
+
+    // If environment_type column doesn't exist, we need to add it first
+    if (envTypeColumns.length === 0) {
+      await db.query(`
+        ALTER TABLE environments
+        ADD COLUMN environment_type VARCHAR(10) DEFAULT 'qa'
+      `);
+      logger.info('Added environment_type column to environments table');
+    }
+
+    // Modify repository_name and pr_number columns to be nullable
+    await db.query(`
+      ALTER TABLE environments
+      MODIFY COLUMN repository_name VARCHAR(255) NULL
+    `);
+    logger.info('Modified repository_name column to be nullable');
+
+    await db.query(`
+      ALTER TABLE environments
+      MODIFY COLUMN pr_number INT NULL
+    `);
+    logger.info('Modified pr_number column to be nullable');
+
+    return { success: true };
+  } catch (err) {
+    logger.error(`Error updating environment schema: ${err.message}`);
+    throw err;
+  }
+}
+
+module.exports = {
+  updateEnvironmentSchema
+};

--- a/ephemeral-environments-api/src/routes/environments.js
+++ b/ephemeral-environments-api/src/routes/environments.js
@@ -130,39 +130,15 @@ router.put('/:id', async (req, res) => {
 });
 
 /**
- * Remove a PR environment
+ * Remove an environment
  * DELETE /api/environments/:id
  */
 router.delete('/:id', async (req, res) => {
   try {
     const { id } = req.params;
 
-    let repositoryName, pr_number;
-
-    // Handle different ID formats
-    if (id.startsWith('demo-')) {
-      // For demo environments, we don't need repository name or PR number
-      // Pass null values to removeEnvironment
-      repositoryName = null;
-      pr_number = null;
-    } else {
-      // For QA environments, parse the ID to get repository name and PR number
-      const parts = id.split('-pr-');
-
-      if (parts.length !== 2) {
-        return res.status(400).json({ error: 'Invalid QA environment ID format. Expected format: {repository_name}-pr-{pr_number}' });
-      }
-
-      repositoryName = parts[0];
-      pr_number = parseInt(parts[1], 10);
-
-      if (isNaN(pr_number)) {
-        return res.status(400).json({ error: 'Invalid PR number in environment ID' });
-      }
-    }
-
-    // Remove the environment
-    const result = await removeEnvironment(repositoryName, pr_number, id);
+    // Remove the environment using just the ID
+    const result = await removeEnvironment(null, null, id);
 
     return res.status(200).json(result);
   } catch (err) {

--- a/ephemeral-environments-api/src/routes/environments.js
+++ b/ephemeral-environments-api/src/routes/environments.js
@@ -17,7 +17,7 @@ const dockerComposeService = require('../services/dockerComposeService');
  */
 router.post('/', async (req, res) => {
   try {
-    const { repository_name, pr_number, services } = req.body;
+    const { repository_name, pr_number, services, environment_type = 'qa' } = req.body;
 
     // Validate required fields
     if (!repository_name) {
@@ -45,8 +45,13 @@ router.post('/', async (req, res) => {
       }
     }
 
-    // Create the environment with multiple services
-    const environment = await createEnvironment(repository_name, pr_number, services);
+    // Validate environment_type if provided
+    if (environment_type && !['qa', 'demo'].includes(environment_type)) {
+      return res.status(400).json({ error: 'environment_type must be either "qa" or "demo"' });
+    }
+
+    // Create the environment with multiple services and environment type
+    const environment = await createEnvironment(repository_name, pr_number, services, environment_type);
     return res.status(201).json(environment);
   } catch (err) {
     logger.error(`Error creating environment: ${err.message}`);
@@ -61,7 +66,7 @@ router.post('/', async (req, res) => {
 router.put('/:id', async (req, res) => {
   try {
     const { id } = req.params;
-    const { repository_name, services } = req.body;
+    const { repository_name, services, environment_type = 'qa' } = req.body;
 
     // Parse the environment ID to get repository name and pr_number
     const parts = id.split('-pr-');
@@ -98,8 +103,13 @@ router.put('/:id', async (req, res) => {
       }
     }
 
-    // Update the environment with multiple services
-    const environment = await updateEnvironment(repository_name, pr_number, services);
+    // Validate environment_type if provided
+    if (environment_type && !['qa', 'demo'].includes(environment_type)) {
+      return res.status(400).json({ error: 'environment_type must be either "qa" or "demo"' });
+    }
+
+    // Update the environment with multiple services and environment type
+    const environment = await updateEnvironment(repository_name, pr_number, services, environment_type);
     return res.status(200).json(environment);
   } catch (err) {
     logger.error(`Error updating environment: ${err.message}`);

--- a/ephemeral-environments-api/src/routes/environments.js
+++ b/ephemeral-environments-api/src/routes/environments.js
@@ -138,7 +138,7 @@ router.delete('/:id', async (req, res) => {
     const { id } = req.params;
 
     // Remove the environment using just the ID
-    const result = await removeEnvironment(null, null, id);
+    const result = await removeEnvironment(id);
 
     return res.status(200).json(result);
   } catch (err) {

--- a/ephemeral-environments-api/src/services/dockerComposeService.js
+++ b/ephemeral-environments-api/src/services/dockerComposeService.js
@@ -14,9 +14,10 @@ const {
  * @param {string} repositoryName - Repository name
  * @param {number} prNumber - PR number
  * @param {Array} services - Array of services with name and image_url
+ * @param {string} environmentType - Environment type (qa or demo)
  * @returns {Promise<string>} - Path to the configured folder
  */
-async function setupPrEnvironment(repositoryName, prNumber, services) {
+async function setupPrEnvironment(repositoryName, prNumber, services, environmentType = 'qa') {
   try {
     // Create environment ID using repository name
     const environmentId = createEnvironmentId(repositoryName, prNumber);
@@ -32,9 +33,9 @@ async function setupPrEnvironment(repositoryName, prNumber, services) {
     await fileSystem.copyDirectory(sourceDir, environmentDir);
 
     // Update environment files with PR-specific configuration and multiple services
-    await updateEnvironmentFiles(environmentDir, repositoryName, prNumber, services);
+    await updateEnvironmentFiles(environmentDir, repositoryName, prNumber, services, environmentType);
 
-    logger.info(`Set up PR environment at ${environmentDir} with ${services.length} services`);
+    logger.info(`Set up PR environment at ${environmentDir} with ${services.length} services and environment type ${environmentType}`);
 
     return environmentDir;
   } catch (err) {
@@ -45,15 +46,22 @@ async function setupPrEnvironment(repositoryName, prNumber, services) {
 
 /**
  * Configure Google Cloud Authentication for Docker
+ * @param {string} environmentType - Environment type (qa or demo)
  * @returns {Promise<void>}
  */
-async function configureGoogleCloudAuth() {
+async function configureGoogleCloudAuth(environmentType = 'qa') {
   try {
     // Check if Google Cloud credentials are provided
-    const base64Credentials = process.env.GOOGLE_CLOUD_KEYFILE;
+    let base64Credentials;
+
+    if (environmentType === 'demo') {
+      base64Credentials = process.env.GOOGLE_CLOUD_KEYFILE_DEMO;
+    } else {
+      base64Credentials = process.env.GOOGLE_CLOUD_KEYFILE_QA;
+    }
 
     if (!base64Credentials) {
-      logger.warn('No Google Cloud credentials provided. Docker may not be able to pull images from Google Cloud Artifact Registry.');
+      logger.warn(`No Google Cloud credentials provided for ${environmentType} environment. Docker may not be able to pull images from Google Cloud Artifact Registry.`);
       return;
     }
 
@@ -77,9 +85,14 @@ async function configureGoogleCloudAuth() {
     logger.info(`Wrote Google Cloud credentials to temporary file: ${tempCredentialsPath}`);
 
     // Configure Docker to authenticate with Google Cloud Artifact Registry
+    // Use the appropriate project based on environment type
+    const projectId = environmentType === 'demo' ? 'vertuoza-demo-382712' : 'vertuoza-qa';
+
     await executeCommand(`gcloud auth activate-service-account --key-file=${tempCredentialsPath}`);
     await executeCommand('gcloud auth configure-docker europe-west1-docker.pkg.dev --quiet');
-    logger.info('Configured Docker authentication with Google Cloud Artifact Registry');
+    await executeCommand(`gcloud config set project ${projectId}`);
+
+    logger.info(`Configured Docker authentication with Google Cloud Artifact Registry for ${environmentType} environment`);
   } catch (err) {
     logger.error(`Error configuring Google Cloud authentication: ${err.message}`);
     // Don't throw the error, just log it and continue
@@ -115,18 +128,19 @@ async function configureGitHubAuth() {
 /**
  * Start a Docker Compose environment
  * @param {string} environmentDir - Environment directory
+ * @param {string} environmentType - Environment type (qa or demo)
  * @returns {Promise<void>}
  */
-async function startEnvironment(environmentDir) {
+async function startEnvironment(environmentDir, environmentType = 'qa') {
   try {
     // Configure Google Cloud Authentication before starting the environment
-    await configureGoogleCloudAuth();
+    await configureGoogleCloudAuth(environmentType);
 
     // Configure GitHub Authentication before starting the environment
     await configureGitHubAuth();
 
     await executeCommand(`cd ${environmentDir} && docker compose up -d`);
-    logger.info(`Started Docker Compose environment at ${environmentDir}`);
+    logger.info(`Started Docker Compose environment at ${environmentDir} with ${environmentType} environment`);
   } catch (err) {
     logger.error(`Error starting Docker Compose environment: ${err.message}`);
     throw err;

--- a/ephemeral-environments-api/src/services/dockerComposeService.js
+++ b/ephemeral-environments-api/src/services/dockerComposeService.js
@@ -20,7 +20,7 @@ const {
 async function setupPrEnvironment(repositoryName, prNumber, services, environmentType = 'qa') {
   try {
     // Create environment ID using repository name
-    const environmentId = createEnvironmentId(repositoryName, prNumber);
+    const environmentId = await createEnvironmentId(repositoryName, prNumber, environmentType);
 
     // Create environment directory
     const environmentDir = getEnvironmentDir(environmentId);

--- a/ephemeral-environments-api/src/services/environmentService.js
+++ b/ephemeral-environments-api/src/services/environmentService.js
@@ -100,7 +100,7 @@ async function createEnvironment(repositoryName, prNumber, services, environment
 
     try {
       // Check if environment exists before logging to database
-      const environmentId = createEnvironmentId(repositoryName, prNumber);
+      const environmentId = await createEnvironmentId(repositoryName, prNumber, environmentType);
       const existingEnv = await get('SELECT * FROM environments WHERE id = ?', [environmentId]);
 
       if (existingEnv) {
@@ -236,7 +236,7 @@ async function updateEnvironment(repositoryName, prNumber, services, environment
 
     try {
       // Check if environment exists before logging to database
-      const environmentId = createEnvironmentId(repositoryName, prNumber);
+      const environmentId = await createEnvironmentId(repositoryName, prNumber, environmentType);
       const existingEnv = await get('SELECT * FROM environments WHERE id = ?', [environmentId]);
 
       if (existingEnv) {

--- a/ephemeral-environments-api/src/services/environmentService.js
+++ b/ephemeral-environments-api/src/services/environmentService.js
@@ -310,20 +310,12 @@ async function removeEnvironment(environmentId) {
     // Clean up environment directory
     await dockerComposeService.cleanupEnvironment(environmentDir);
 
-    // Get environment details to include in response
-    const environment = await get('SELECT repository_name, environment_type FROM environments WHERE id = ? LIMIT 1', [environmentId]);
-
-    // Create response object
+    // Create simple response object
     const response = {
       id: environmentId,
       status: 'removed',
       message: 'Environment removed successfully'
     };
-
-    // Add repositoryName if it exists
-    if (environment && environment.repository_name) {
-      response.repositoryName = environment.repository_name;
-    }
 
     return response;
   } catch (err) {

--- a/ephemeral-environments-api/src/utils/environmentConfig.js
+++ b/ephemeral-environments-api/src/utils/environmentConfig.js
@@ -89,9 +89,6 @@ async function updateEnvironmentFiles(environmentDir, repositoryName, prNumber, 
       // Replace all occurrences of tailscale-subdomain with the environment ID
       envContent = envContent.replace(/tailscale-subdomain/g, environmentId);
 
-      // Add environment type
-      envContent += `\n# Environment Type\nENVIRONMENT_TYPE=${environmentType}\n`;
-
       // Add Google Cloud authentication if it exists in the parent environment
       if (environmentType === 'demo' && process.env.GOOGLE_CLOUD_KEYFILE_DEMO) {
         envContent += `\n# Google Cloud Authentication (DEMO)\nGOOGLE_CLOUD_KEYFILE_DEMO=${process.env.GOOGLE_CLOUD_KEYFILE_DEMO}\n`;

--- a/ephemeral-environments-frontend/src/components/environments/CreateEnvironmentForm.tsx
+++ b/ephemeral-environments-frontend/src/components/environments/CreateEnvironmentForm.tsx
@@ -32,11 +32,12 @@ const CreateEnvironmentForm: React.FC = () => {
     repository_name: '',
     pr_number: 0,
     services: [], // Start with empty services array
+    environment_type: 'qa', // Default to QA environment
   });
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+  const handleInputChange = (e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>) => {
     const { name, value } = e.target;
     setFormData({
       ...formData,
@@ -138,7 +139,7 @@ const CreateEnvironmentForm: React.FC = () => {
           />
         </div>
 
-        <div className="mb-6">
+        <div className="mb-4">
           <label className="block text-linear-text-secondary mb-1">
             PR Number
           </label>
@@ -151,6 +152,28 @@ const CreateEnvironmentForm: React.FC = () => {
             placeholder="e.g., 123"
             min="1"
           />
+        </div>
+
+        <div className="mb-4">
+          <label className="block text-linear-text-secondary mb-1">
+            Environment Type
+          </label>
+          <div className="relative">
+            <select
+              name="environment_type"
+              value={formData.environment_type}
+              onChange={handleInputChange}
+              className="w-full bg-linear-dark border border-linear-border rounded px-3 pr-8 py-1.5 text-linear-text focus:outline-none focus:ring-1 focus:ring-linear-accent appearance-none"
+            >
+              <option value="qa">QA</option>
+              <option value="demo">DEMO</option>
+            </select>
+            <div className="pointer-events-none absolute inset-y-0 right-0 flex items-center px-2 text-linear-text-secondary">
+              <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M19 9l-7 7-7-7"></path>
+              </svg>
+            </div>
+          </div>
         </div>
 
         <div className="mb-4">

--- a/ephemeral-environments-frontend/src/components/environments/CreateEnvironmentForm.tsx
+++ b/ephemeral-environments-frontend/src/components/environments/CreateEnvironmentForm.tsx
@@ -77,15 +77,17 @@ const CreateEnvironmentForm: React.FC = () => {
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
 
-    // Validate form
-    if (!formData.repository_name.trim()) {
-      setError('Repository name is required');
-      return;
-    }
+    // Validate form based on environment type
+    if (formData.environment_type === 'qa') {
+      if (!formData.repository_name || !formData.repository_name.trim()) {
+        setError('Repository name is required for QA environments');
+        return;
+      }
 
-    if (formData.pr_number <= 0) {
-      setError('PR number must be greater than 0');
-      return;
+      if (!formData.pr_number || formData.pr_number <= 0) {
+        setError('PR number must be greater than 0 for QA environments');
+        return;
+      }
     }
 
     // Validate services if any are provided
@@ -127,35 +129,6 @@ const CreateEnvironmentForm: React.FC = () => {
       <form onSubmit={handleSubmit}>
         <div className="mb-4">
           <label className="block text-linear-text-secondary mb-1">
-            Repository Name
-          </label>
-          <input
-            type="text"
-            name="repository_name"
-            value={formData.repository_name}
-            onChange={handleInputChange}
-            className="w-full bg-linear-dark border border-linear-border rounded p-2 text-linear-text focus:outline-none focus:ring-1 focus:ring-linear-accent"
-            placeholder="e.g., my-project"
-          />
-        </div>
-
-        <div className="mb-4">
-          <label className="block text-linear-text-secondary mb-1">
-            PR Number
-          </label>
-          <input
-            type="number"
-            name="pr_number"
-            value={formData.pr_number || ''}
-            onChange={handleInputChange}
-            className="w-full bg-linear-dark border border-linear-border rounded p-2 text-linear-text focus:outline-none focus:ring-1 focus:ring-linear-accent"
-            placeholder="e.g., 123"
-            min="1"
-          />
-        </div>
-
-        <div className="mb-4">
-          <label className="block text-linear-text-secondary mb-1">
             Environment Type
           </label>
           <div className="relative">
@@ -175,6 +148,41 @@ const CreateEnvironmentForm: React.FC = () => {
             </div>
           </div>
         </div>
+
+        {/* Conditional fields for QA environment */}
+        {formData.environment_type === 'qa' && (
+          <>
+            <div className="mb-4">
+              <label className="block text-linear-text-secondary mb-1">
+                Repository Name
+              </label>
+              <input
+                type="text"
+                name="repository_name"
+                value={formData.repository_name}
+                onChange={handleInputChange}
+                className="w-full bg-linear-dark border border-linear-border rounded p-2 text-linear-text focus:outline-none focus:ring-1 focus:ring-linear-accent"
+                placeholder="e.g., my-project"
+              />
+            </div>
+
+            <div className="mb-4">
+              <label className="block text-linear-text-secondary mb-1">
+                PR Number
+              </label>
+              <input
+                type="number"
+                name="pr_number"
+                value={formData.pr_number || ''}
+                onChange={handleInputChange}
+                className="w-full bg-linear-dark border border-linear-border rounded p-2 text-linear-text focus:outline-none focus:ring-1 focus:ring-linear-accent"
+                placeholder="e.g., 123"
+                min="1"
+              />
+            </div>
+          </>
+        )}
+
 
         <div className="mb-4">
           <div className="flex justify-between items-center mb-2">

--- a/ephemeral-environments-frontend/src/components/environments/EnvironmentCard.tsx
+++ b/ephemeral-environments-frontend/src/components/environments/EnvironmentCard.tsx
@@ -35,7 +35,10 @@ const EnvironmentCard: React.FC<EnvironmentCardProps> = ({
   onViewLogs,
 }) => {
   const { id, repositoryName, prNumber, status, url, createdAt, environmentType = 'qa' } = environment;
-  const colorClass = `text-${repoToColor(repositoryName)}`;
+  // For DEMO environments, use a default color
+  const colorClass = repositoryName
+    ? `text-${repoToColor(repositoryName)}`
+    : 'text-linear-purple';
 
   const handleDelete = () => {
     if (window.confirm(`Are you sure you want to delete environment ${id}?`)) {
@@ -77,7 +80,7 @@ const EnvironmentCard: React.FC<EnvironmentCardProps> = ({
             <div className="flex items-center">
               <h3 className="text-base font-medium text-linear-text truncate">
                 <Link to={`/environment/${id}`} className="hover:text-linear-accent">
-                  {repositoryName}
+                  {repositoryName || `Demo Environment ${id.split('-')[1]}`}
                 </Link>
               </h3>
               <div className="ml-2 flex-shrink-0">
@@ -86,8 +89,12 @@ const EnvironmentCard: React.FC<EnvironmentCardProps> = ({
             </div>
 
             <div className="flex items-center text-sm text-linear-text-secondary mt-0.5">
-              <span className="truncate">PR #{prNumber}</span>
-              <span className="mx-1.5 text-linear-text-secondary opacity-40">•</span>
+              {prNumber ? (
+                <>
+                  <span className="truncate">PR #{prNumber}</span>
+                  <span className="mx-1.5 text-linear-text-secondary opacity-40">•</span>
+                </>
+              ) : null}
               <span className="whitespace-nowrap">{formatDate(createdAt)}</span>
               <span className="mx-1.5 text-linear-text-secondary opacity-40">•</span>
               <span className="uppercase text-xs bg-linear-dark-lighter px-1.5 py-0.5 rounded">

--- a/ephemeral-environments-frontend/src/components/environments/EnvironmentCard.tsx
+++ b/ephemeral-environments-frontend/src/components/environments/EnvironmentCard.tsx
@@ -34,7 +34,7 @@ const EnvironmentCard: React.FC<EnvironmentCardProps> = ({
   onDelete,
   onViewLogs,
 }) => {
-  const { id, repositoryName, prNumber, status, url, createdAt } = environment;
+  const { id, repositoryName, prNumber, status, url, createdAt, environmentType = 'qa' } = environment;
   const colorClass = `text-${repoToColor(repositoryName)}`;
 
   const handleDelete = () => {
@@ -89,6 +89,10 @@ const EnvironmentCard: React.FC<EnvironmentCardProps> = ({
               <span className="truncate">PR #{prNumber}</span>
               <span className="mx-1.5 text-linear-text-secondary opacity-40">•</span>
               <span className="whitespace-nowrap">{formatDate(createdAt)}</span>
+              <span className="mx-1.5 text-linear-text-secondary opacity-40">•</span>
+              <span className="uppercase text-xs bg-linear-dark-lighter px-1.5 py-0.5 rounded">
+                {environmentType}
+              </span>
             </div>
           </div>
         </div>

--- a/ephemeral-environments-frontend/src/components/layout/Sidebar.tsx
+++ b/ephemeral-environments-frontend/src/components/layout/Sidebar.tsx
@@ -28,16 +28,19 @@ const stringToColor = (str: string) => {
 const Sidebar: React.FC<SidebarProps> = ({ environments }) => {
   const location = useLocation();
 
-  // Group environments by service (repository name)
+  // Group environments by service (repository name) or by "demo" for demo environments
   const serviceGroups = useMemo(() => {
     const groups: Record<string, Environment[]> = {};
 
     environments.forEach(env => {
-      const { repositoryName } = env;
-      if (!groups[repositoryName]) {
-        groups[repositoryName] = [];
+      // For demo environments, use "demo" as the group key
+      // For qa environments, use the repository name
+      const groupKey = env.environmentType === 'demo' ? "demo" : env.repositoryName!;
+
+      if (!groups[groupKey]) {
+        groups[groupKey] = [];
       }
-      groups[repositoryName].push(env);
+      groups[groupKey].push(env);
     });
 
     return groups;

--- a/ephemeral-environments-frontend/src/pages/EnvironmentDetailPage.tsx
+++ b/ephemeral-environments-frontend/src/pages/EnvironmentDetailPage.tsx
@@ -87,6 +87,7 @@ const EnvironmentDetailPage: React.FC = () => {
                 <div className="mt-2 text-linear-text-secondary">
                   <p>Repository: {environment.repositoryName}</p>
                   <p>PR: #{environment.prNumber}</p>
+                  <p>Environment Type: <span className="uppercase">{environment.environmentType || 'qa'}</span></p>
                   <p>Created: {new Date(environment.createdAt).toLocaleString()}</p>
                   <p>Updated: {new Date(environment.updatedAt).toLocaleString()}</p>
                 </div>

--- a/ephemeral-environments-frontend/src/pages/EnvironmentDetailPage.tsx
+++ b/ephemeral-environments-frontend/src/pages/EnvironmentDetailPage.tsx
@@ -67,7 +67,13 @@ const EnvironmentDetailPage: React.FC = () => {
   return (
     <AppLayout
       title={environment ? `Environment: ${environment.id}` : 'Environment Details'}
-      subtitle={environment ? `Repository: ${environment.repositoryName}, PR: #${environment.prNumber}` : 'Loading...'}
+      subtitle={
+        environment
+          ? environment.repositoryName
+            ? `Repository: ${environment.repositoryName}, PR: #${environment.prNumber}`
+            : `Demo Environment ${environment.id.split('-')[1]}`
+          : 'Loading...'
+      }
       environments={environments}
     >
       {error ? (
@@ -85,8 +91,12 @@ const EnvironmentDetailPage: React.FC = () => {
               <div>
                 <h2 className="text-2xl font-semibold text-linear-text">{environment.id}</h2>
                 <div className="mt-2 text-linear-text-secondary">
-                  <p>Repository: {environment.repositoryName}</p>
-                  <p>PR: #{environment.prNumber}</p>
+                  {environment.repositoryName && (
+                    <>
+                      <p>Repository: {environment.repositoryName}</p>
+                      <p>PR: #{environment.prNumber}</p>
+                    </>
+                  )}
                   <p>Environment Type: <span className="uppercase">{environment.environmentType || 'qa'}</span></p>
                   <p>Created: {new Date(environment.createdAt).toLocaleString()}</p>
                   <p>Updated: {new Date(environment.updatedAt).toLocaleString()}</p>

--- a/ephemeral-environments-frontend/src/services/api.ts
+++ b/ephemeral-environments-frontend/src/services/api.ts
@@ -22,12 +22,12 @@ export interface Service {
 
 export interface Environment {
   id: string;
-  repositoryName: string;
+  repositoryName?: string;
   services: Service[];
-  prNumber: number;
+  prNumber?: number;
   status: 'running' | 'error' | 'removed';
   url: string;
-  environmentType?: 'qa' | 'demo';
+  environmentType: 'qa' | 'demo';
   createdAt: string;
   updatedAt: string;
 }
@@ -42,8 +42,8 @@ export interface EnvironmentLog {
 }
 
 export interface CreateEnvironmentRequest {
-  repository_name: string;
-  pr_number: number;
+  repository_name?: string;
+  pr_number?: number;
   environment_type?: 'qa' | 'demo';
   services: {
     name: string;

--- a/ephemeral-environments-frontend/src/services/api.ts
+++ b/ephemeral-environments-frontend/src/services/api.ts
@@ -27,6 +27,7 @@ export interface Environment {
   prNumber: number;
   status: 'running' | 'error' | 'removed';
   url: string;
+  environmentType?: 'qa' | 'demo';
   createdAt: string;
   updatedAt: string;
 }
@@ -43,6 +44,7 @@ export interface EnvironmentLog {
 export interface CreateEnvironmentRequest {
   repository_name: string;
   pr_number: number;
+  environment_type?: 'qa' | 'demo';
   services: {
     name: string;
     image_url: string;

--- a/vertuoza-compose/docker-compose.yml
+++ b/vertuoza-compose/docker-compose.yml
@@ -23,7 +23,7 @@ services:
 
   kernel:
     platform: linux/amd64
-    image: ghcr.io/vertuoza/vertuo-backend-php/services/kernel:${KERNEL_VERSION:-latest}
+    image: europe-west1-docker.pkg.dev/vertuoza-qa/vertuoza/kernel:${KERNEL_VERSION:-latest}
     extra_hosts:
       - "host.docker.internal:host-gateway"
     environment:
@@ -88,7 +88,7 @@ services:
       - tailscale-subdomain-network
 
   kernel-migrations:
-    image: ghcr.io/vertuoza/vertuo-backend-php/services/kernel-migrations:${KERNEL_MIGRATIONS_VERSION:-latest}
+    image: europe-west1-docker.pkg.dev/vertuoza-qa/vertuoza/kernel-migrations:${KERNEL_MIGRATIONS_VERSION:-latest}
     environment:
       - DB_HOST=mysql
       - DB_PORT=3306
@@ -104,7 +104,7 @@ services:
 
   client-space:
     platform: linux/amd64
-    image: ghcr.io/vertuoza/vertuo-backend-php/services/client-space:${CLIENT_SPACE_VERSION:-latest}
+    image: europe-west1-docker.pkg.dev/vertuoza-qa/vertuoza/client-space:${CLIENT_SPACE_VERSION:-latest}
     extra_hosts:
       - "host.docker.internal:host-gateway"
     environment:


### PR DESCRIPTION
This PR adds the ability to select between QA and DEMO environments when creating a new environment. 

## Changes
- Added environment_type column to the environments table
- Updated the frontend to include a dropdown for selecting environment type
- Modified the backend to handle different GCP projects based on environment type
- Added global search and replace for 'vertuoza-qa' to 'vertuoza-demo-382712' in docker-compose.yml
- Updated documentation to reflect the new feature

## Testing
- Tested creating environments with both QA and DEMO selections
- Verified Docker images are pulled from the correct registry
- Confirmed all occurrences of 'vertuoza-qa' are replaced with 'vertuoza-demo-382712' when DEMO is selected