### PR TITLE
Update hostname and improve Docker cleanup strategy

### DIFF
--- a/ephemeral-environments-api/src/services/dockerComposeService.js
+++ b/ephemeral-environments-api/src/services/dockerComposeService.js
@@ -155,10 +155,11 @@ async function startEnvironment(environmentDir, environmentType = 'qa') {
  */
 async function stopEnvironment(environmentDir) {
   try {
+    // Stop and remove containers, networks, and volumes for this environment
     await executeCommand(`cd ${environmentDir} && docker compose down -v --remove-orphans`);
 
-    // Clean up any dangling containers, images, and volumes
-    await executeCommand('docker system prune -af');
+    // Clean up only dangling images (conservative approach)
+    await executeCommand('docker image prune -f');
 
     logger.info(`Stopped Docker Compose environment at ${environmentDir}`);
   } catch (err) {

--- a/vertuoza-compose/docker-compose.yml
+++ b/vertuoza-compose/docker-compose.yml
@@ -640,7 +640,7 @@ services:
     healthcheck:
       test: ["CMD", "mysqladmin", "ping", "-h", "localhost"]
       interval: 20s
-      timeout: 1s
+      timeout: 10s
       retries: 5
 
   postgres:


### PR DESCRIPTION
- Change Tailscale hostname to ephemeral-environments-buisson
- Replace aggressive docker system prune with conservative image cleanup
- Increase MySQL healthcheck timeout from 1s to 10s for reliability