### PR TITLE
Update Tailscale hostnames and improve MySQL healthcheck

### DIFF
--- a/vertuoza-compose/docker-compose.yml
+++ b/vertuoza-compose/docker-compose.yml
@@ -11,7 +11,7 @@ services:
       - TS_STATE_DIR=/var/lib/tailscale
       - TS_USERSPACE=false
     volumes:
-      - ${COMPOSE_PROJECT_ROOT:-${PWD}}/vertuoza-compose/config:/config
+      - ${COMPOSE_PROJECT_ROOT:-${PWD}/..}/vertuoza-compose/config:/config
       - vertuoza-ts-state:/var/lib/tailscale
     devices:
       - /dev/net/tun:/dev/net/tun
@@ -638,9 +638,9 @@ services:
         limits:
           memory: 1024M
     healthcheck:
-      test: ["CMD", "mysqladmin", "ping", "-h", "localhost"]
+      test: ["CMD", "mysql", "-h", "localhost", "-u", "kernel", "-pkernel_password", "-e", "SELECT 1 FROM information_schema.tables WHERE table_schema='vertuoza_dvp' LIMIT 1;"]
       interval: 20s
-      timeout: 1s
+      timeout: 10s
       retries: 5
 
   postgres:


### PR DESCRIPTION
- Add "-buisson" suffix to Tailscale hostnames for better identification
- Fix volume path in vertuoza-compose configuration
- Replace MySQL healthcheck with more robust database connectivity test
- Increase healthcheck timeout from 1s to 10s for reliability